### PR TITLE
:sparkles: Add common response format - ApiResponse

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     // Swagger
     implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
     implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'

--- a/src/main/java/dev/line4/blackBoard/utils/controller/CustomErrorController.java
+++ b/src/main/java/dev/line4/blackBoard/utils/controller/CustomErrorController.java
@@ -1,0 +1,35 @@
+package dev.line4.blackBoard.utils.controller;
+
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import dev.line4.blackBoard.utils.response.ApiResponse;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+public class CustomErrorController implements ErrorController {
+
+    @RequestMapping("/error") // 지정한 엔드포인트 외의 경로로 들어오면 여기로 매핑
+    public ResponseEntity<ApiResponse<Object>> handleError(HttpServletRequest request) {
+        Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+
+        if (status != null) {
+            int statusCode = Integer.parseInt(status.toString());
+
+            if (statusCode == HttpStatus.NOT_FOUND.value()) {
+                return ResponseEntity
+                        .status(HttpStatus.NOT_FOUND)
+                        .body(new ApiResponse<>(HttpStatus.NOT_FOUND.value(), null, "요청 경로를 찾을 수 없습니다."));
+            }
+        }
+
+        // 다른 HTTP 오류에 대한 처리
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ApiResponse<>(HttpStatus.INTERNAL_SERVER_ERROR.value(), null, "내부 서버 오류가 발생했습니다."));
+    }
+}

--- a/src/main/java/dev/line4/blackBoard/utils/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dev/line4/blackBoard/utils/exception/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package dev.line4.blackBoard.utils.exception;
+
+import dev.line4.blackBoard.utils.response.ApiResponse;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import java.util.stream.Collectors;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidationException(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult().getAllErrors().stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.joining("; "));
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail(HttpStatus.BAD_REQUEST.value(), errorMessage));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<?>> handleConstraintViolationException(ConstraintViolationException e) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .collect(Collectors.joining("; "));
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail(HttpStatus.BAD_REQUEST.value(), errorMessage));
+    }
+
+}

--- a/src/main/java/dev/line4/blackBoard/utils/response/ApiResponse.java
+++ b/src/main/java/dev/line4/blackBoard/utils/response/ApiResponse.java
@@ -1,0 +1,48 @@
+package dev.line4.blackBoard.utils.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApiResponse<T> {
+
+    private static final int OK = 200;
+    private static final int BAD_REQUEST = 400;
+    private static final int NOT_FOUND = 404;
+
+    private int status;
+    private T data;
+    private String message;
+
+    public static <T> ApiResponse<T> success(T data, String message) {
+        return new ApiResponse<>(OK, data, message);
+    }
+
+    public static <T> ApiResponse<T> fail(int status, String message) {
+        return new ApiResponse<>(status, null, message);
+    }
+
+    public static <T> ApiResponse<T> fail(int status, BindingResult bindingResult) {
+        List<String> errorMessages = bindingResult.getAllErrors().stream()
+                .map(ObjectError::getObjectName)
+                .collect(Collectors.toList());
+
+        String combinedMessage = String.join("; ", errorMessages);
+
+        return new ApiResponse<>(status, null, combinedMessage);
+    }
+
+    public ApiResponse(int status, T data, String message) {
+        this.status = status;
+        this.data = data;
+        this.message = message;
+    }
+
+}

--- a/src/main/java/dev/line4/blackBoard/utils/test/TestController.java
+++ b/src/main/java/dev/line4/blackBoard/utils/test/TestController.java
@@ -1,26 +1,34 @@
 package dev.line4.blackBoard.utils.test;
 
+import dev.line4.blackBoard.utils.response.ApiResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+
+@Validated
 @RestController
 @RequestMapping("api")
 @Api(tags = "테스트")
 public class TestController {
 
-    @GetMapping("test")
-    @ApiOperation(value = "테스트", notes = "프론트와 통신 시 테스트 목적으로 호출합니다.")
-    @ApiResponses({
-            @ApiResponse(code = 200, message = "테스트 성공입니다.")
-    })
-    public ResponseEntity<?> test() {
-        return ResponseEntity.status(HttpStatus.OK).body("테스트 성공입니다.");
+    @GetMapping("test-success")
+    public ResponseEntity<?> testSuccess() {
+        return ResponseEntity.status(HttpStatus.OK.value()).body(ApiResponse.success("this is data", "test success"));
+    }
+
+    @GetMapping("test-not-found/{email}")
+    public ResponseEntity<?> testNotFound(@PathVariable("email") @NotEmpty(message = "비어있을 수 없습니다.") @Email(message = "이메일 형식을 맞춰주세요.") String email) {
+        char lowerCase = Character.toLowerCase(email.charAt(1));
+        return ResponseEntity.status(HttpStatus.OK.value()).body(ApiResponse.success("this is data", "조회 성공"));
     }
 }


### PR DESCRIPTION
### Key Points
- close #4 
- Add ApiResponse, GlobalException, CustomErrorController, and modify TestController to test changes

<br>

### Details

#### ApiResponse

- The response form of all APIs in this project will follow the following format.

```jsonc
{
    status : 200,
    message : "hello",
    data : { 
        "data1 key" : "data1 value" 
    }
}
```

<br>

#### GlobalException

- If `MethodArgumentNotValidException`, `ConstraintViolationException` occur, they are handled here.

- A response is made according to the format of the ApiResponse class.

<br>

#### TestController

- A controller was written to test the above items.

- request 1)  http://localhost:8080/api/test-success

```jsonc
{
    "status": 200,
    "data": "this is data",
    "message": "test success"
}
```


- request 2) http://localhost:8080/api/test-not-found/k

```jsonc
{
    "status": 400,
    "data": null,
    "message": "이메일 형식을 맞춰주세요."
}
```

<br>

#### CustomErrorController

- If a request comes to an endpoint that does not exist, a response is returned through this controller.

```jsonc
{
    status : 404,
    message : { "요청 경로를 찾을 수 없습니다." },
    data : null
}
```

