### PR TITLE
:card_file_box: Add BaseEntity - createdAt, lastModifiedAt field

### DIFF
--- a/src/main/java/dev/line4/blackBoard/BlackBoardApplication.java
+++ b/src/main/java/dev/line4/blackBoard/BlackBoardApplication.java
@@ -1,12 +1,10 @@
 package dev.line4.blackBoard;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.EntityTransaction;
-import javax.persistence.Persistence;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BlackBoardApplication {
 

--- a/src/main/java/dev/line4/blackBoard/blackboard/entity/BlackBoards.java
+++ b/src/main/java/dev/line4/blackBoard/blackboard/entity/BlackBoards.java
@@ -12,6 +12,8 @@ import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+
+import dev.line4.blackBoard.utils.entity.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,7 +36,7 @@ url text
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "BLACKBOARD")
-public class BlackBoards {
+public class BlackBoards extends BaseEntity {
     @Id
     private String id;
     @Column(length = 50)

--- a/src/main/java/dev/line4/blackBoard/blackboardsticker/entity/BlackBoardStickers.java
+++ b/src/main/java/dev/line4/blackBoard/blackboardsticker/entity/BlackBoardStickers.java
@@ -17,6 +17,8 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+
+import dev.line4.blackBoard.utils.entity.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,7 +32,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "BLACKBOARD_STICKERS")
-public class BlackBoardStickers {
+public class BlackBoardStickers extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/dev/line4/blackBoard/entity/BlackBoardsEntity.java
+++ b/src/main/java/dev/line4/blackBoard/entity/BlackBoardsEntity.java
@@ -2,6 +2,8 @@ package dev.line4.blackBoard.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import dev.line4.blackBoard.letter.entity.Letters;
+import dev.line4.blackBoard.utils.entity.BaseEntity;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +26,7 @@ url text
 */
 
 @Entity
-public class BlackBoardsEntity {
+public class BlackBoardsEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/dev/line4/blackBoard/letter/entity/Letters.java
+++ b/src/main/java/dev/line4/blackBoard/letter/entity/Letters.java
@@ -17,6 +17,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+
+import dev.line4.blackBoard.utils.entity.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,7 +32,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "LETTER")
-public class Letters {
+public class Letters extends BaseEntity {
 
     @Id
     @Column(name = "letter_id")

--- a/src/main/java/dev/line4/blackBoard/lettersticker/entity/LetterStickers.java
+++ b/src/main/java/dev/line4/blackBoard/lettersticker/entity/LetterStickers.java
@@ -12,6 +12,8 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+
+import dev.line4.blackBoard.utils.entity.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,7 +27,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "LETTER_STICKERS")
-public class LetterStickers {
+public class LetterStickers extends BaseEntity {
 
     @Id
     @Column(name = "letter_sticker_id")

--- a/src/main/java/dev/line4/blackBoard/utils/entity/BaseEntity.java
+++ b/src/main/java/dev/line4/blackBoard/utils/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package dev.line4.blackBoard.utils.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "last_modified_at")
+    private LocalDateTime lastModifiedAt;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,6 @@ spring.jpa.show-sql=true
 spring.datasource.url=jdbc:mysql://localhost:3306/black_board
 spring.datasource.username=root
 spring.datasource.password=1234
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
 # Swagger2
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher


### PR DESCRIPTION
### Key Points
- close #10 
- All entities use BaseEntity

<br>

### Details

#### BaseEntity

- The `@MappedSuperclass` annotation was used to inherit mapping information.
- BaseEntity class has `createdAt`, `lastModifiedAt` fields.
- In order to automate fields, `@CreatedDate` and `@LastModifiedDate` annotations were added to the fields. 
- To handle the entity's life cycle events, the `@EntityListeners(AuditingEntityListener.class)` annotation is attached to this class unit.

<br>

#### Other entities

- To use BaseEntity, Except for BaseEntity, all entities extends BaseEntity.

<br>

#### Main

- To enable JPA Auditing, `@EnableJpaAuditing` annotation was added to the main class.

<br>

### ⚠️ Warning

- To test above changes, I changed from `spring.jpa.hibernate.ddl-auto=update` to `spring.jpa.hibernate.ddl-auto=create` in `application.yml` file.