### PR TITLE
:recycle: Change entity, class, method names

### DIFF
--- a/src/main/java/dev/line4/blackBoard/blackboard/controller/BlackBoardController.java
+++ b/src/main/java/dev/line4/blackBoard/blackboard/controller/BlackBoardController.java
@@ -1,6 +1,6 @@
 package dev.line4.blackBoard.blackboard.controller;
 
-import dev.line4.blackBoard.blackboard.dto.CreateBlackBoardDto;
+import dev.line4.blackBoard.blackboard.dto.AddBlackBoardDto;
 import dev.line4.blackBoard.blackboard.service.BlackBoardServiceImpl;
 import dev.line4.blackBoard.utils.response.ApiResponse;
 import io.swagger.annotations.Api;
@@ -25,27 +25,28 @@ public class BlackBoardController {
     // 완료
     @GetMapping("blackboards")
     @ApiOperation(value = "칠판 개수", notes = "현재까지 생성된 칠판의 개수를 리턴합니다.")
-    public ResponseEntity<ApiResponse<?>> getBlackBoardCount() {
-        ResponseEntity<ApiResponse<?>> result = blackBoardServiceImpl.getBlackBoardCount();
+    public ResponseEntity<ApiResponse<?>> countBlackBoards() {
+        ResponseEntity<ApiResponse<?>> result = blackBoardServiceImpl.countBlackBoards();
         return result;
     }
 
     // 완료
     @PostMapping("blackboard")
     @ApiOperation(value = "칠판 생성", notes = "칠판을 생성할 때 호출합니다.")
-    public ResponseEntity<ApiResponse<?>> createBlackBoard(@RequestBody CreateBlackBoardDto.Req req) {
-        ResponseEntity<ApiResponse<?>> result = blackBoardServiceImpl.createBlackBoard(req);
+    public ResponseEntity<ApiResponse<?>> addBlackBoard(@RequestBody AddBlackBoardDto.Req req) {
+        ResponseEntity<ApiResponse<?>> result = blackBoardServiceImpl.addBlackBoard(req);
         return result;
     }
 
     // 완료
     @GetMapping("blackboard")
     @ApiOperation(value = "칠판과 편지", notes = "칠판을 조회할 때 호출합니다.")
-    public ResponseEntity<ApiResponse<?>> getBlackBoardAndLetter(@RequestParam("userId") String userId) {
-        ResponseEntity<ApiResponse<?>> result = blackBoardServiceImpl.getBlackBoardAndLetter(userId);
+    public ResponseEntity<ApiResponse<?>> readBlackBoardAndLetters(@RequestParam("userId") String userId) {
+        ResponseEntity<ApiResponse<?>> result = blackBoardServiceImpl.readBlackBoardAndLetters(userId);
         return result;
     }
 
+    // 완료
     @GetMapping("check-duplicate")
     @ApiOperation(value = "userId 중복 확인", notes = "userId를 입력받은 후 호출합니다.")
     public ResponseEntity<ApiResponse<?>> checkDuplicateUserId(@RequestParam("userId") String userId) {

--- a/src/main/java/dev/line4/blackBoard/blackboard/dto/AddBlackBoardDto.java
+++ b/src/main/java/dev/line4/blackBoard/blackboard/dto/AddBlackBoardDto.java
@@ -1,7 +1,7 @@
-package dev.line4.blackBoard.letter.dto;
+package dev.line4.blackBoard.blackboard.dto;
 
-import dev.line4.blackBoard.letter.entity.Letters;
-import dev.line4.blackBoard.lettersticker.entity.LetterStickers;
+import dev.line4.blackBoard.blackboard.entity.BlackBoardEntity;
+import dev.line4.blackBoard.blackboardsticker.entity.BlackBoardStickerEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,38 +9,30 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-public class CreateLetterDto {
+public class AddBlackBoardDto {
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class Req {
 
-        private Letter letter;
+        private BlackBoard blackboard;
         private List<Sticker> stickers;
 
         @Getter
         @NoArgsConstructor(access = AccessLevel.PROTECTED)
-        public static class Letter {
-            private String nickname;
-            private String content;
-            private String font;
-            private String align;
+        public static class BlackBoard {
+            private String title;
+            private String introduction;
+            private String userId;
+            private String openDate;
 
-            public Letters toEntity() {
-                return Letters.builder()
-                        .nickname(this.nickname)
-                        .content(this.content)
-                        .font(this.font)
-                        .align(this.align)
+            public BlackBoardEntity toEntity() {
+                return BlackBoardEntity.builder()
+                        .title(this.title)
+                        .introduction(this.introduction)
+                        .userId(this.userId)
+                        .openDate(this.openDate)
                         .build();
-            }
-
-            @Builder
-            public Letter(String nickname, String content, String font, String align) {
-                this.nickname = nickname;
-                this.content = content;
-                this.font = font;
-                this.align = align;
             }
         }
 
@@ -55,8 +47,8 @@ public class CreateLetterDto {
             private Double angle;
             private Long mirror;
 
-            public LetterStickers toEntity() {
-                return LetterStickers.builder()
+            public BlackBoardStickerEntity toEntity() {
+                return BlackBoardStickerEntity.builder()
                         .num(this.num)
                         .positionX(this.positionX)
                         .positionY(this.positionY)
@@ -66,6 +58,19 @@ public class CreateLetterDto {
                         .mirror(this.mirror)
                         .build();
             }
+        }
+
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Res {
+
+        private String userId;
+
+        @Builder
+        public Res(String userId) {
+            this.userId = userId;
         }
     }
 }

--- a/src/main/java/dev/line4/blackBoard/blackboard/dto/CountBlackBoardsDto.java
+++ b/src/main/java/dev/line4/blackBoard/blackboard/dto/CountBlackBoardsDto.java
@@ -3,7 +3,7 @@ package dev.line4.blackBoard.blackboard.dto;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
-public class GetBlackBoardCountDto {
+public class CountBlackBoardsDto {
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/dev/line4/blackBoard/blackboard/dto/ReadBlackBoardAndLettersDto.java
+++ b/src/main/java/dev/line4/blackBoard/blackboard/dto/ReadBlackBoardAndLettersDto.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-public class GetBlackBoardAndLetterDto {
+public class ReadBlackBoardAndLettersDto {
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/dev/line4/blackBoard/blackboard/entity/BlackBoardEntity.java
+++ b/src/main/java/dev/line4/blackBoard/blackboard/entity/BlackBoardEntity.java
@@ -1,8 +1,8 @@
 package dev.line4.blackBoard.blackboard.entity;
 
-import dev.line4.blackBoard.blackboard.dto.CreateBlackBoardDto;
-import dev.line4.blackBoard.blackboardsticker.entity.BlackBoardStickers;
-import dev.line4.blackBoard.letter.entity.Letters;
+import dev.line4.blackBoard.blackboard.dto.AddBlackBoardDto;
+import dev.line4.blackBoard.blackboardsticker.entity.BlackBoardStickerEntity;
+import dev.line4.blackBoard.letter.entity.LetterEntity;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.*;
@@ -25,7 +25,7 @@ url text
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "BLACKBOARD")
-public class BlackBoards extends BaseEntity {
+public class BlackBoardEntity extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -44,14 +44,14 @@ public class BlackBoards extends BaseEntity {
 
     @Builder.Default
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<BlackBoardStickers> blackBoardStickers = new ArrayList<>(); // 초기화 추가;
+    private List<BlackBoardStickerEntity> blackBoardStickers = new ArrayList<>(); // 초기화 추가;
 
     @Builder.Default
     @OneToMany(mappedBy = "blackboard", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<Letters> letters = new ArrayList<>();
+    private List<LetterEntity> letters = new ArrayList<>();
 
     // 생성 메서드
-    public static BlackBoards createBlackBoard(CreateBlackBoardDto.Req req) {
+    public static BlackBoardEntity createBlackBoard(AddBlackBoardDto.Req req) {
             return req.getBlackboard().toEntity();
     }
 

--- a/src/main/java/dev/line4/blackBoard/blackboard/repository/BlackBoardRepository.java
+++ b/src/main/java/dev/line4/blackBoard/blackboard/repository/BlackBoardRepository.java
@@ -1,13 +1,13 @@
 package dev.line4.blackBoard.blackboard.repository;
 
-import dev.line4.blackBoard.blackboard.entity.BlackBoards;
+import dev.line4.blackBoard.blackboard.entity.BlackBoardEntity;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface BlackBoardRepository extends JpaRepository<BlackBoards, String> {
-    Optional<BlackBoards> findBlackBoardsByUserId(String userId);
+public interface BlackBoardRepository extends JpaRepository<BlackBoardEntity, String> {
+    Optional<BlackBoardEntity> findBlackBoardsByUserId(String userId);
 
     boolean existsByUserId(String userId);
 }

--- a/src/main/java/dev/line4/blackBoard/blackboard/service/BlackBoardService.java
+++ b/src/main/java/dev/line4/blackBoard/blackboard/service/BlackBoardService.java
@@ -1,19 +1,19 @@
 package dev.line4.blackBoard.blackboard.service;
 
-import dev.line4.blackBoard.blackboard.dto.CreateBlackBoardDto;
+import dev.line4.blackBoard.blackboard.dto.AddBlackBoardDto;
 import dev.line4.blackBoard.utils.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 
 public interface BlackBoardService {
 
     // 생성된 칠판의 개수 가져오기
-    ResponseEntity<ApiResponse<?>> getBlackBoardCount();
+    ResponseEntity<ApiResponse<?>> countBlackBoards();
 
     // 칠판 생성하기
-    ResponseEntity<ApiResponse<?>> createBlackBoard(CreateBlackBoardDto.Req req) throws Exception;
+    ResponseEntity<ApiResponse<?>> addBlackBoard(AddBlackBoardDto.Req req) throws Exception;
 
     // 칠판, 편지 조회
-    ResponseEntity<ApiResponse<?>> getBlackBoardAndLetter(String userId);
+    ResponseEntity<ApiResponse<?>> readBlackBoardAndLetters(String userId);
 
     // 아이디 중복 확인
     ResponseEntity<ApiResponse<?>> checkDuplicateUserId(String userId);

--- a/src/main/java/dev/line4/blackBoard/blackboardsticker/entity/BlackBoardStickerEntity.java
+++ b/src/main/java/dev/line4/blackBoard/blackboardsticker/entity/BlackBoardStickerEntity.java
@@ -1,7 +1,7 @@
 package dev.line4.blackBoard.blackboardsticker.entity;
 
-import dev.line4.blackBoard.blackboard.dto.CreateBlackBoardDto;
-import dev.line4.blackBoard.blackboard.entity.BlackBoards;
+import dev.line4.blackBoard.blackboard.dto.AddBlackBoardDto;
+import dev.line4.blackBoard.blackboard.entity.BlackBoardEntity;
 
 import javax.persistence.*;
 
@@ -14,7 +14,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "BLACKBOARD_STICKERS")
-public class BlackBoardStickers extends BaseEntity {
+public class BlackBoardStickerEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,15 +42,15 @@ public class BlackBoardStickers extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id")
-    private BlackBoards board;
+    private BlackBoardEntity board;
 
     // 생성 메서드
-    public static BlackBoardStickers createBlackBoardSticker(CreateBlackBoardDto.Req.Sticker req) {
+    public static BlackBoardStickerEntity createBlackBoardSticker(AddBlackBoardDto.Req.Sticker req) {
         return req.toEntity();
     }
 
     // 연관관계 편의 메서드
-    public void setBlackBoard(BlackBoards blackBoard) {
+    public void setBlackBoard(BlackBoardEntity blackBoard) {
         this.board = blackBoard;
         board.getBlackBoardStickers().add(this);
     }

--- a/src/main/java/dev/line4/blackBoard/blackboardsticker/repository/BlackBoardStickerRepository.java
+++ b/src/main/java/dev/line4/blackBoard/blackboardsticker/repository/BlackBoardStickerRepository.java
@@ -1,9 +1,9 @@
 package dev.line4.blackBoard.blackboardsticker.repository;
 
-import dev.line4.blackBoard.blackboardsticker.entity.BlackBoardStickers;
+import dev.line4.blackBoard.blackboardsticker.entity.BlackBoardStickerEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface BlackBoardStickerRepository extends JpaRepository<BlackBoardStickers, Long> {
+public interface BlackBoardStickerRepository extends JpaRepository<BlackBoardStickerEntity, Long> {
 }

--- a/src/main/java/dev/line4/blackBoard/blackboardsticker/service/BlackBoardStickerServiceImpl.java
+++ b/src/main/java/dev/line4/blackBoard/blackboardsticker/service/BlackBoardStickerServiceImpl.java
@@ -1,9 +1,9 @@
 package dev.line4.blackBoard.blackboardsticker.service;
 
-import dev.line4.blackBoard.blackboard.dto.CreateBlackBoardDto;
-import dev.line4.blackBoard.blackboard.dto.GetBlackBoardAndLetterDto;
-import dev.line4.blackBoard.blackboard.entity.BlackBoards;
-import dev.line4.blackBoard.blackboardsticker.entity.BlackBoardStickers;
+import dev.line4.blackBoard.blackboard.dto.AddBlackBoardDto;
+import dev.line4.blackBoard.blackboard.dto.ReadBlackBoardAndLettersDto;
+import dev.line4.blackBoard.blackboard.entity.BlackBoardEntity;
+import dev.line4.blackBoard.blackboardsticker.entity.BlackBoardStickerEntity;
 import dev.line4.blackBoard.blackboardsticker.repository.BlackBoardStickerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,12 +17,12 @@ public class BlackBoardStickerServiceImpl implements BlackBoardStickerService {
 
     private final BlackBoardStickerRepository blackBoardStickerRepository;
 
-    public List<BlackBoardStickers> createStickers(List<CreateBlackBoardDto.Req.Sticker> stickerList, BlackBoards blackBoard) {
+    public List<BlackBoardStickerEntity> createStickers(List<AddBlackBoardDto.Req.Sticker> stickerList, BlackBoardEntity blackBoard) {
 
         // 스티커 엔티티 생성 및 초기화
-        List<BlackBoardStickers> stickers = stickerList.stream()
+        List<BlackBoardStickerEntity> stickers = stickerList.stream()
                 .map(stickerDto -> {
-                    BlackBoardStickers sticker = BlackBoardStickers.createBlackBoardSticker(stickerDto);
+                    BlackBoardStickerEntity sticker = BlackBoardStickerEntity.createBlackBoardSticker(stickerDto);
                     sticker.setBlackBoard(blackBoard);
                     return sticker;
                 })
@@ -35,9 +35,9 @@ public class BlackBoardStickerServiceImpl implements BlackBoardStickerService {
     }
 
     // 칠판 스티커 DTO 변환 메서드
-    public List<GetBlackBoardAndLetterDto.Sticker> convertToBlackBoardStickerDtoList(BlackBoards blackBoard) {
+    public List<ReadBlackBoardAndLettersDto.Sticker> convertToBlackBoardStickerDtoList(BlackBoardEntity blackBoard) {
         return blackBoard.getBlackBoardStickers().stream()
-                .map(sticker -> GetBlackBoardAndLetterDto.Sticker.builder()
+                .map(sticker -> ReadBlackBoardAndLettersDto.Sticker.builder()
                         .num(sticker.getNum())
                         .positionX(sticker.getPositionX())
                         .positionY(sticker.getPositionY())

--- a/src/main/java/dev/line4/blackBoard/letter/controller/LetterController.java
+++ b/src/main/java/dev/line4/blackBoard/letter/controller/LetterController.java
@@ -1,6 +1,6 @@
 package dev.line4.blackBoard.letter.controller;
 
-import dev.line4.blackBoard.letter.dto.CreateLetterDto;
+import dev.line4.blackBoard.letter.dto.AddLetterDto;
 import dev.line4.blackBoard.letter.service.LetterServiceImpl;
 import dev.line4.blackBoard.utils.response.ApiResponse;
 import io.swagger.annotations.Api;
@@ -19,16 +19,16 @@ public class LetterController {
 
     @PostMapping("letter")
     @ApiOperation(value = "편지 생성", notes = "편지를 생성할 때 호출합니다.")
-    public ResponseEntity<ApiResponse<?>> createLetter(@RequestBody CreateLetterDto.Req req,
+    public ResponseEntity<ApiResponse<?>> addLetter(@RequestBody AddLetterDto.Req req,
                                                     @RequestParam("userId") String userId) {
-        ResponseEntity<ApiResponse<?>> result = letterService.createLetter(userId, req);
+        ResponseEntity<ApiResponse<?>> result = letterService.addLetter(userId, req);
         return result;
     }
 
     @GetMapping("writer")
     @ApiOperation(value = "편지 작성자 조회", notes = "칠판에 편지를 작성한 사람들을 조회할 때 호출합니다.")
-    public ResponseEntity<ApiResponse<?>> readWriter(@RequestParam("userId") String userId) {
-        ResponseEntity<ApiResponse<?>> result = letterService.readWriter(userId);
+    public ResponseEntity<ApiResponse<?>> getLetterWriters(@RequestParam("userId") String userId) {
+        ResponseEntity<ApiResponse<?>> result = letterService.getLetterWriters(userId);
         return result;
     }
 

--- a/src/main/java/dev/line4/blackBoard/letter/dto/AddLetterDto.java
+++ b/src/main/java/dev/line4/blackBoard/letter/dto/AddLetterDto.java
@@ -1,7 +1,7 @@
-package dev.line4.blackBoard.blackboard.dto;
+package dev.line4.blackBoard.letter.dto;
 
-import dev.line4.blackBoard.blackboard.entity.BlackBoards;
-import dev.line4.blackBoard.blackboardsticker.entity.BlackBoardStickers;
+import dev.line4.blackBoard.letter.entity.LetterEntity;
+import dev.line4.blackBoard.lettersticker.entity.LetterStickerEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,30 +9,38 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-public class CreateBlackBoardDto {
+public class AddLetterDto {
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class Req {
 
-        private BlackBoard blackboard;
+        private Letter letter;
         private List<Sticker> stickers;
 
         @Getter
         @NoArgsConstructor(access = AccessLevel.PROTECTED)
-        public static class BlackBoard {
-            private String title;
-            private String introduction;
-            private String userId;
-            private String openDate;
+        public static class Letter {
+            private String nickname;
+            private String content;
+            private String font;
+            private String align;
 
-            public BlackBoards toEntity() {
-                return BlackBoards.builder()
-                        .title(this.title)
-                        .introduction(this.introduction)
-                        .userId(this.userId)
-                        .openDate(this.openDate)
+            public LetterEntity toEntity() {
+                return LetterEntity.builder()
+                        .nickname(this.nickname)
+                        .content(this.content)
+                        .font(this.font)
+                        .align(this.align)
                         .build();
+            }
+
+            @Builder
+            public Letter(String nickname, String content, String font, String align) {
+                this.nickname = nickname;
+                this.content = content;
+                this.font = font;
+                this.align = align;
             }
         }
 
@@ -47,8 +55,8 @@ public class CreateBlackBoardDto {
             private Double angle;
             private Long mirror;
 
-            public BlackBoardStickers toEntity() {
-                return BlackBoardStickers.builder()
+            public LetterStickerEntity toEntity() {
+                return LetterStickerEntity.builder()
                         .num(this.num)
                         .positionX(this.positionX)
                         .positionY(this.positionY)
@@ -58,19 +66,6 @@ public class CreateBlackBoardDto {
                         .mirror(this.mirror)
                         .build();
             }
-        }
-
-    }
-
-    @Getter
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class Res {
-
-        private String userId;
-
-        @Builder
-        public Res(String userId) {
-            this.userId = userId;
         }
     }
 }

--- a/src/main/java/dev/line4/blackBoard/letter/dto/GetLetterWritersDto.java
+++ b/src/main/java/dev/line4/blackBoard/letter/dto/GetLetterWritersDto.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-public class ReadWriterDto {
+public class GetLetterWritersDto {
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/dev/line4/blackBoard/letter/entity/LetterEntity.java
+++ b/src/main/java/dev/line4/blackBoard/letter/entity/LetterEntity.java
@@ -1,12 +1,11 @@
 package dev.line4.blackBoard.letter.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import dev.line4.blackBoard.blackboard.entity.BlackBoards;
-import dev.line4.blackBoard.letter.dto.CreateLetterDto;
-import dev.line4.blackBoard.lettersticker.entity.LetterStickers;
+import dev.line4.blackBoard.blackboard.entity.BlackBoardEntity;
+import dev.line4.blackBoard.letter.dto.AddLetterDto;
+import dev.line4.blackBoard.lettersticker.entity.LetterStickerEntity;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -28,7 +27,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "LETTER")
-public class Letters extends BaseEntity {
+public class LetterEntity extends BaseEntity {
 
     @Id
     @Column(name = "letter_id")
@@ -50,20 +49,20 @@ public class Letters extends BaseEntity {
     @JsonIgnore
     @JoinColumn(name = "board_id")
     @ManyToOne(fetch = FetchType.LAZY)
-    private BlackBoards blackboard; // FK
+    private BlackBoardEntity blackboard; // FK
 
     @JsonIgnore
     @Builder.Default
     @OneToMany(mappedBy = "letter", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<LetterStickers> letterStickers = new ArrayList<>();
+    private List<LetterStickerEntity> letterStickers = new ArrayList<>();
 
     // 생성 메서드
-    public static Letters createLetter(CreateLetterDto.Req.Letter req) {
+    public static LetterEntity createLetter(AddLetterDto.Req.Letter req) {
         return req.toEntity();
     }
 
     // 연관관계 메서드
-    public void setBlackBoard(BlackBoards blackBoard) {
+    public void setBlackBoard(BlackBoardEntity blackBoard) {
         this.blackboard = blackBoard;
         blackBoard.getLetters().add(this);
     }

--- a/src/main/java/dev/line4/blackBoard/letter/repository/LetterRepository.java
+++ b/src/main/java/dev/line4/blackBoard/letter/repository/LetterRepository.java
@@ -1,9 +1,9 @@
 package dev.line4.blackBoard.letter.repository;
 
-import dev.line4.blackBoard.letter.entity.Letters;
+import dev.line4.blackBoard.letter.entity.LetterEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface LetterRepository extends JpaRepository<Letters, Long> {
+public interface LetterRepository extends JpaRepository<LetterEntity, Long> {
 }

--- a/src/main/java/dev/line4/blackBoard/letter/service/LetterService.java
+++ b/src/main/java/dev/line4/blackBoard/letter/service/LetterService.java
@@ -1,15 +1,15 @@
 package dev.line4.blackBoard.letter.service;
 
-import dev.line4.blackBoard.blackboard.dto.GetBlackBoardAndLetterDto;
-import dev.line4.blackBoard.letter.dto.CreateLetterDto;
-import dev.line4.blackBoard.letter.entity.Letters;
+import dev.line4.blackBoard.blackboard.dto.ReadBlackBoardAndLettersDto;
+import dev.line4.blackBoard.letter.dto.AddLetterDto;
+import dev.line4.blackBoard.letter.entity.LetterEntity;
 import dev.line4.blackBoard.utils.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 
 public interface LetterService {
-    ResponseEntity<ApiResponse<?>> createLetter(String userId, CreateLetterDto.Req req);
-    ResponseEntity<ApiResponse<?>> readWriter(String userId);
-    List<GetBlackBoardAndLetterDto.Res.Letter> convertToLetterAndLetterStickerDtoList(List<Letters> letters);
+    ResponseEntity<ApiResponse<?>> addLetter(String userId, AddLetterDto.Req req);
+    ResponseEntity<ApiResponse<?>> getLetterWriters(String userId);
+    List<ReadBlackBoardAndLettersDto.Res.Letter> convertToLetterAndLetterStickerDtoList(List<LetterEntity> letters);
 }

--- a/src/main/java/dev/line4/blackBoard/lettersticker/entity/LetterStickerEntity.java
+++ b/src/main/java/dev/line4/blackBoard/lettersticker/entity/LetterStickerEntity.java
@@ -1,8 +1,8 @@
 package dev.line4.blackBoard.lettersticker.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import dev.line4.blackBoard.letter.dto.CreateLetterDto;
-import dev.line4.blackBoard.letter.entity.Letters;
+import dev.line4.blackBoard.letter.dto.AddLetterDto;
+import dev.line4.blackBoard.letter.entity.LetterEntity;
 import dev.line4.blackBoard.utils.entity.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -27,7 +27,7 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "LETTER_STICKERS")
-public class LetterStickers extends BaseEntity {
+public class LetterStickerEntity extends BaseEntity {
 
     @Id
     @Column(name = "letter_sticker_id")
@@ -58,10 +58,10 @@ public class LetterStickers extends BaseEntity {
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "letter_id")
-    private Letters letter;
+    private LetterEntity letter;
 
     // 생성 메서드
-    public static LetterStickers createLetterSticker(CreateLetterDto.Req.Sticker dto) {
+    public static LetterStickerEntity createLetterSticker(AddLetterDto.Req.Sticker dto) {
         return dto.toEntity();
     }
 }

--- a/src/main/java/dev/line4/blackBoard/lettersticker/repository/LetterStickerRepository.java
+++ b/src/main/java/dev/line4/blackBoard/lettersticker/repository/LetterStickerRepository.java
@@ -1,14 +1,13 @@
 package dev.line4.blackBoard.lettersticker.repository;
 
-import dev.line4.blackBoard.letter.entity.Letters;
-import dev.line4.blackBoard.lettersticker.entity.LetterStickers;
+import dev.line4.blackBoard.letter.entity.LetterEntity;
+import dev.line4.blackBoard.lettersticker.entity.LetterStickerEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
-public interface LetterStickerRepository extends JpaRepository<LetterStickers, Long> {
-    List<LetterStickers> findAllByLetter(Letters letter);
+public interface LetterStickerRepository extends JpaRepository<LetterStickerEntity, Long> {
+    List<LetterStickerEntity> findAllByLetter(LetterEntity letter);
 }


### PR DESCRIPTION
### Key Points

- refs #34 
- Change method name to RESTful, also change associated class, method name
- Change entities name

<br>

### Details

**method**

- BlackBoard
    
    - from `getBlackBoardCount` to `countBlackBoards`
    - from `createBlackBoard` to `addBlackBoard`
    - from `getBlackBoardAndLetter` to `readBlackBoardAndLetters`

<br>

- Letter

    - from `createLetter` to `addLetter`
    - from `readWriter` to `getLetterWriters`

<br>

**entity**
- from `BlackBoards` to `BlackBoardEntity`
- from `BlackBoardSticker` to `BlackBoardStickerEntity`
- from `Letter ` to `LetterEntity`
- from `LetterSticker ` to `LetterStickerEntity`